### PR TITLE
Fix error conditions for BaseConnectionUnix

### DIFF
--- a/src/main/java/com/github/psnrigner/discordrpcjava/impl/BaseConnectionUnix.java
+++ b/src/main/java/com/github/psnrigner/discordrpcjava/impl/BaseConnectionUnix.java
@@ -184,17 +184,17 @@ class BaseConnectionUnix extends BaseConnection
         String desktopFileName = "/discord-" + applicationId + ".desktop";
         String desktopFilePath = home + "/.local";
 
-        if (this.mkdir(desktopFilePath))
+        if (!this.mkdir(desktopFilePath))
             throw new RuntimeException("Failed to create directory '" + desktopFilePath + "'");
 
         desktopFilePath += "/share";
 
-        if (this.mkdir(desktopFilePath))
+        if (!this.mkdir(desktopFilePath))
             throw new RuntimeException("Failed to create directory '" + desktopFilePath + "'");
 
         desktopFilePath += "/applications";
 
-        if (this.mkdir(desktopFilePath))
+        if (!this.mkdir(desktopFilePath))
             throw new RuntimeException("Failed to create directory '" + desktopFilePath + "'");
 
         desktopFilePath += desktopFileName;


### PR DESCRIPTION
It should only throw an exception if the folder is not created.